### PR TITLE
fix overlap on iPhone 4 and iPhone 5 devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -1020,7 +1020,7 @@
             </tr>
             <tr>
               <td><code>customChildrenBefore</code></td>
-              <td>The same as <code>customChildren</code>, but inserted
+              <td>The same as the above property, but inserted
               as the first child element(s) of the component.</td>
             </tr>
           </tbody>


### PR DESCRIPTION
A minor change, but still useful nonetheless. When visiting hyper.is on a mobile device, a [certain table](https://github.com/zeit/hyper-website/blob/master/index.html#L1022) overlaps the device's width, causing a horizontal scrollbar to appear at the bottom of the screen. When a user scrolls down to read the webpage, they may accidentally swipe diagonally, causing the page to be shifted slightly to the left.

Like I said, not that big of a deal but it bothered me so I had to fix it. Perhaps someone could automate browser testing so this doesn't happen in the future?