### PR TITLE
Add hint to transparent terminal

### DIFF
--- a/index.html
+++ b/index.html
@@ -515,7 +515,7 @@
             <tr>
               <td>"backgroundColor"</td>
               <td>"#000"</td>
-              <td>The color of the window and main terminal background</td>
+              <td>The color and opacity of the window and main terminal background</td>
             </tr>
             <tr>
               <td>"borderColor"</td>


### PR DESCRIPTION
I've added a hint pointing to transparency of the terminal, since new people might not now that a transparent terminal is possible. If I would't have read the release notes I would't now.