### PR TITLE
update config docs, "clearSelection" to "copyOnSelect"

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,7 +558,7 @@
               <td>The default width/height in pixels of a new window e.g. [540, 380]</td>
             </tr>
             <tr>
-              <td>"clearSelection"</td>
+              <td>"copyOnSelect"</td>
               <td>false</td>
               <td>If true, selected text will automatically be copied to the clipboard</td>
             </tr>


### PR DESCRIPTION
Seems like `copyOnSelect` was mistakenly written up as `clearSelection` on the homepage docs. (Also mentioned in https://github.com/zeit/hyper/issues/878#issuecomment-254928824.)

This PR fixes that.