### PR TITLE
add configuration docs for 'showHamburgerMenu' and 'showWindowControls'

### DIFF
--- a/index.html
+++ b/index.html
@@ -671,8 +671,8 @@
 
         <p><code>Hyper</code> will show a notification when your modules are
         installed to <code>~/.hyper_plugins</code>.</p>
-
-        <p>You can also take a look at
+        
+        <p>You can also take a look at 
           <a href="https://github.com/bnb/awesome-hyper">Awesome Hyper</a>
           for a curated list of plugins and resources.</p>
 

--- a/index.html
+++ b/index.html
@@ -671,8 +671,8 @@
 
         <p><code>Hyper</code> will show a notification when your modules are
         installed to <code>~/.hyper_plugins</code>.</p>
-        
-        <p>You can also take a look at 
+
+        <p>You can also take a look at
           <a href="https://github.com/bnb/awesome-hyper">Awesome Hyper</a>
           for a curated list of plugins and resources.</p>
 
@@ -784,6 +784,22 @@
                 }
               </td>
               <td>Change the behaviour of modifier keys to act as meta key</td>
+            </tr>
+            <tr>
+              <td>"showHamburgerMenu"</td>
+              <td>""</td>
+              <td>
+                Change the visibility of the hamburger menu. Available options
+                are: true, false
+              </td>
+            </tr>
+            <tr>
+              <td>"showWindowControls"</td>
+              <td>""</td>
+              <td>
+                Change the position/visibility of the window controls.
+                Available options are: true, false, "left"
+              </td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
Added documentation for "showHamburgerMenu" and "showWindowControls" to the configuration table. The documentation for the "Property", "Default", and "Description" table values has been derived from the the hyper repository (lib/reducers/ui.js); specifically, lines: [25](https://github.com/zeit/hyper/blob/master/lib/reducers/ui.js#L25), [26](https://github.com/zeit/hyper/blob/master/lib/reducers/ui.js#L26), [85](https://github.com/zeit/hyper/blob/master/lib/reducers/ui.js#L85), [86](https://github.com/zeit/hyper/blob/master/lib/reducers/ui.js#L86). Would be happy to change if I am missing something. Thanks! 